### PR TITLE
Fix Vite entry references for build

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,7 @@
     <meta name="keywords" content="dog walking, dog training, Jacksonville, dog adventures, GPS tracking, dog boarding, pet services" />
     <meta name="author" content="TrekSnout" />
     <title>TrekSnout - Jacksonville Dog Adventures & Training</title>
-    <script type="module" crossorigin src="/assets/index-D7hmFjk9.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BRX0Hjq9.css">
+    <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- update the HTML entry point to load the Vite source module instead of stale hashed assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbcfa6f8608329bc40f33d2ce0dbe8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace hashed asset references with the Vite module `/src/main.tsx` in `index.html`.
> 
> - **HTML entry (`index.html`)**:
>   - Replace built asset references (`/assets/index-*.js`, `/assets/index-*.css`) with Vite source module `src/main.tsx`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5fdee85d705a3c1f67e1c876d4e052428d84511. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->